### PR TITLE
Fix incorrect Git clone URL in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,8 +36,8 @@ depending on connection speed and various other factors.
 
 1. Clone this repository:
 ```bash
-git clone http://github.com/icpc-env/icpc-environment.git icpcenv
-cd icpcenv
+git clone https://github.com/icpc-environment/icpc-env.git
+cd icpc-env
 ```
 
 2. Make sure dependencies are met


### PR DESCRIPTION
The organisation name and repository name were the wrong way round.

Also switch from HTTP to HTTPS, which is more secure (GitHub redirects to HTTPS if one tries to use HTTP).

Also insert a hyphen in the destination directory's name to match the repository's name (which is the default destination directory).